### PR TITLE
Update logic for finding taunt targets

### DIFF
--- a/hsgame/game_objects.py
+++ b/hsgame/game_objects.py
@@ -181,7 +181,7 @@ class Minion(Bindable):
         found_taunt = False
         targets = []
         for enemy in self.game.other_player.minions:
-            if enemy.taunt:
+            if enemy.taunt and not enemy.stealth:
                 found_taunt = True
             if not enemy.stealth:
                 targets.append(enemy)


### PR DESCRIPTION
A minion can have taunt AND stealth at the same time. However, stealth have priority over taunt so the code shouldn't say that taunt was found if the minion have stealth active as well.
